### PR TITLE
A likely solution to the mobile landing page scroll problem

### DIFF
--- a/src/components/Home/Home.jsx
+++ b/src/components/Home/Home.jsx
@@ -5,6 +5,7 @@ import logoOrange from "../../assets/logo-orange.png";
 import "../../utility/fonts.css";
 import styled from 'styled-components';
 import devices from '../../utility/MediaQueries.js';
+import $ from 'jquery';
 
 import SpecialNavbar from '../SpecialNavbar.jsx';
 
@@ -48,18 +49,27 @@ const Logo = styled.img`
 `
 
 class Home extends Component {
-  render() {
-    return (
-      <React.Fragment>
-        <SpecialNavbar />
-        <PolygonCanvas style={{width: '100%', height: '100%', position: 'absolute', transform: "scaleX(-1)"}}/>
-        <HomeBackgroundOuter>
-          <Logo src={logoUrl}/>
-          <MainText>a community of individuals who enjoy expressing creativity through technology.</MainText>
-        </HomeBackgroundOuter>
-      </React.Fragment>
-    );
-  }
+
+	componentDidMount() {
+		$("body").css("overflow", "hidden");
+	}
+
+	componentWillUnmount() {
+		$("body").css("overflow", "initial");
+	}
+
+	render() {
+		return (
+			<React.Fragment>
+			<SpecialNavbar />
+			<PolygonCanvas style={{width: '100%', height: '100%', position: 'absolute', transform: "scaleX(-1)"}}/>
+			<HomeBackgroundOuter>
+				<Logo src={logoUrl}/>
+				<MainText>a community of individuals who enjoy expressing creativity through technology.</MainText>
+			</HomeBackgroundOuter>
+			</React.Fragment>
+		);
+	}
 }
 
 export default Home;


### PR DESCRIPTION
Closes #29 

This probably* fixes the problem where scrolling on the home page causes the navbar to be obscured, by disabling scrolling on the page.

*verified on Chrome DevTools' mobile simulator