### PR TITLE
Leadership refresh

### DIFF
--- a/src/components/Leadership/CardContainer.jsx
+++ b/src/components/Leadership/CardContainer.jsx
@@ -12,10 +12,18 @@ const Cards = styled.section`
     width: 100%;
 `;
 
-const CardContainer = ({ people }) => {
+/**
+ * Display a collection of club members
+ * Can accept other html props and pass them down
+ *
+ * @constructor
+ * @param props Other html attributes to use
+ * @param props.people {[{}]} The people to display
+ */
+const CardContainer = (props) => {
     return (
-        <Cards>
-            {people.map((lead) => (
+        <Cards {...props}>
+            {props.people.map((lead) => (
                 <MemberCard
                     {...lead}
                     key={lead.uniqname}

--- a/src/components/Leadership/CardContainer.jsx
+++ b/src/components/Leadership/CardContainer.jsx
@@ -1,12 +1,9 @@
 import React from "react";
 import "utility/fonts.css";
-import { StaticH1 } from "utility/ContentStyles.js";
 import "react-responsive-carousel/lib/styles/carousel.min.css";
 import MemberCard from "./MemberCard.jsx";
+import PropTypes from "prop-types";
 import styled from "styled-components";
-
-// we may want to switch this to using a global variable so the whole json can be updated by itself using public/
-import leadership from "leadership.json";
 
 const Cards = styled.section`
     display: inline-flex;
@@ -15,38 +12,58 @@ const Cards = styled.section`
     width: 100%;
 `;
 
-class CardContainer extends React.Component {
-    constructor() {
-        super();
-        this.state = {
-            leadership: [],
-            categories: [],
-        };
-    }
+const CardContainer = ({ people }) => {
+    return (
+        <Cards>
+            {people.map((lead) => (
+                <div key={lead.uniqname}>
+                    <MemberCard
+                        {...lead}
+                        imageUrl={`${process.env.PUBLIC_URL}/${lead.imageUrl}`}
+                    />
+                </div>
+            ))}
+        </Cards>
+    );
+};
 
-    render() {
-        return (
-            <React.Fragment>
-                {Object.keys(leadership).map((category, index) => (
-                    <div key={index}>
-                        <StaticH1>{category}</StaticH1>
-                        <div>
-                            <Cards>
-                                {leadership[category].map((lead, index) => (
-                                    <div key={index}>
-                                        <MemberCard
-                                            {...lead}
-                                            imageUrl={`${process.env.PUBLIC_URL}/${lead.imageUrl}`}
-                                        />
-                                    </div>
-                                ))}
-                            </Cards>
-                        </div>
-                    </div>
-                ))}
-            </React.Fragment>
-        );
-    }
-}
+// class CardContainer extends React.Component {
+//     constructor() {
+//         super();
+//         this.state = {
+//             leadership: [],
+//             categories: [],
+//         };
+//     }
+//
+//     render() {
+//         return (
+//             <React.Fragment>
+//                 {Object.keys(leadership).map((category, index) => (
+//                     <div key={index}>
+//                         <StaticH1>{category}</StaticH1>
+//                         <div>
+//                             <Cards>
+//                                 {leadership[category].map((lead, index) => (
+//                                     <div key={index}>
+//                                         <MemberCard
+//                                             {...lead}
+//                                             imageUrl={`${process.env.PUBLIC_URL}/${lead.imageUrl}`}
+//                                         />
+//                                     </div>
+//                                 ))}
+//                             </Cards>
+//                         </div>
+//                     </div>
+//                 ))}
+//             </React.Fragment>
+//         );
+//     }
+// }
+
+// TODO: extract out lead type?
+CardContainer.propTypes = {
+    people: PropTypes.arrayOf(PropTypes.object),
+};
 
 export default CardContainer;

--- a/src/components/Leadership/CardContainer.jsx
+++ b/src/components/Leadership/CardContainer.jsx
@@ -27,10 +27,6 @@ class CardContainer extends React.Component {
     render() {
         return (
             <React.Fragment>
-                <link
-                    rel="stylesheet"
-                    href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css"
-                />
                 {Object.keys(leadership).map((category, index) => (
                     <div key={index}>
                         <StaticH1>{category}</StaticH1>

--- a/src/components/Leadership/CardContainer.jsx
+++ b/src/components/Leadership/CardContainer.jsx
@@ -16,50 +16,15 @@ const CardContainer = ({ people }) => {
     return (
         <Cards>
             {people.map((lead) => (
-                <div key={lead.uniqname}>
-                    <MemberCard
-                        {...lead}
-                        imageUrl={`${process.env.PUBLIC_URL}/${lead.imageUrl}`}
-                    />
-                </div>
+                <MemberCard
+                    {...lead}
+                    key={lead.uniqname}
+                    imageUrl={`${process.env.PUBLIC_URL}/${lead.imageUrl}`}
+                />
             ))}
         </Cards>
     );
 };
-
-// class CardContainer extends React.Component {
-//     constructor() {
-//         super();
-//         this.state = {
-//             leadership: [],
-//             categories: [],
-//         };
-//     }
-//
-//     render() {
-//         return (
-//             <React.Fragment>
-//                 {Object.keys(leadership).map((category, index) => (
-//                     <div key={index}>
-//                         <StaticH1>{category}</StaticH1>
-//                         <div>
-//                             <Cards>
-//                                 {leadership[category].map((lead, index) => (
-//                                     <div key={index}>
-//                                         <MemberCard
-//                                             {...lead}
-//                                             imageUrl={`${process.env.PUBLIC_URL}/${lead.imageUrl}`}
-//                                         />
-//                                     </div>
-//                                 ))}
-//                             </Cards>
-//                         </div>
-//                     </div>
-//                 ))}
-//             </React.Fragment>
-//         );
-//     }
-// }
 
 // TODO: extract out lead type?
 CardContainer.propTypes = {

--- a/src/components/Leadership/CardContainer.jsx
+++ b/src/components/Leadership/CardContainer.jsx
@@ -1,6 +1,6 @@
 import React from "react";
-import "../../utility/fonts.css";
-import { StaticH1 } from "../../utility/ContentStyles.js";
+import "utility/fonts.css";
+import { StaticH1 } from "utility/ContentStyles.js";
 import "react-responsive-carousel/lib/styles/carousel.min.css";
 import MemberCard from "./MemberCard.jsx";
 import styled from "styled-components";

--- a/src/components/Leadership/Leadership.jsx
+++ b/src/components/Leadership/Leadership.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useCallback, useEffect, useState } from "react";
 import styled from "styled-components";
 import "utility/fonts.css";
 import Navbar from "components/Navbar.jsx";
@@ -89,11 +89,11 @@ const getTab = (tabIndex) => leadership[TAB_NAMES[tabIndex]];
 function Leadership() {
     const [currentTabIndex, setCurrentTabIndex] = useState(0);
     const location = useLocation();
+    // when the selected tab changes (keyboard, click, or routing with non-empty hash), focus it
+    const selectedTabRef = useCallback(node => location.hash && node?.focus(), []);
 
     const getCurrentTab = () => getTab(currentTabIndex);
 
-    // TODO: shift focus to the correct tab
-    //       will probably need refs
     // Update the hash first; the next render will update the currentTabIndex
     const handleKeyDown = (event) => {
         if (event.key in tabNavigationActions) {
@@ -141,6 +141,7 @@ function Leadership() {
                                 role="tab"
                                 tabIndex={currentTabIndex === i ? "0" : "-1"}
                                 aria-selected={currentTabIndex === i}
+                                ref={currentTabIndex === i ? selectedTabRef : null}
                             >
                                 {group_name}
                             </Tab>

--- a/src/components/Leadership/Leadership.jsx
+++ b/src/components/Leadership/Leadership.jsx
@@ -7,7 +7,8 @@ import CardContainer from "./CardContainer.jsx";
 import CoreTeam from "assets/CoreTeam.JPG";
 import ErichHands from "assets/ErichHands.JPG";
 import Escapade from "assets/Escapade.JPG";
-import { slugify } from "../../utility/utils";
+import { slugify } from "utility/utils";
+import devices from "utility/MediaQueries.js";
 
 import leadership_json from "leadership.json";
 
@@ -19,22 +20,23 @@ const LeadershipWrapper = styled.main`
 const LeadershipGroupImages = styled.div`
     width: 100%;
     height: 400px;
-  display: flex;
-  flex-direction: row;
+    display: flex;
+    flex-direction: row;
+    ${devices.small`
+        display: none;
+    `}
 `;
 
 const LeadershipGroupImage = styled.img.attrs((props) => ({
     isActive: props.isActive,
 }))`
-    width: 100%;
+    width: 33.3%;
     height: 400px;
     background-color: lightgray;
     object-fit: cover;
-  transition: filter 0.3s;
+    transition: filter 0.3s;
+    // has to read the property because not a navlink and will not get a style when active
     ${(props) => props.isActive || "filter: grayscale(100%);"};
-    //&.active {
-    //  filter: grayscale(100%);
-    //}
 `;
 
 const TabNav = styled.nav``;
@@ -44,6 +46,9 @@ const TabGroup = styled.ul`
     margin-bottom: 0;
     //background: rgb(241, 93, 36);
     background: #ed8246;
+    ${devices.small`
+        flex-direction: column;
+    `}
 `;
 const Tab = styled(NavLink)`
     padding: 10px 10px;
@@ -51,7 +56,7 @@ const Tab = styled(NavLink)`
     flex-grow: 1;
     text-align: center;
     color: white;
-  transition: background-color 0.3s;
+    transition: background-color 0.3s;
     &.active {
         background-color: #8dcadf;
     }
@@ -61,7 +66,7 @@ const TabInfo = styled.div`
     background-color: #8dcadf;
     padding: 1.5em 0;
     margin-bottom: 1.5em;
-  transition: content 0.3s;
+    transition: content 0.3s;
 `;
 
 const TabName = styled.h1`
@@ -136,12 +141,15 @@ function Leadership() {
                         <LeadershipGroupImage
                             key={group_name}
                             src={leadership[group_name].image}
-                            isActive={isActive(leadership[group_name].slug, i)(null, location)}
+                            isActive={isActive(leadership[group_name].slug, i)(
+                                null,
+                                location
+                            )}
                         />
                     ))}
                 </LeadershipGroupImages>
                 <TabNav>
-                    <TabGroup role={"tabgroup"}>
+                    <TabGroup role="tablist">
                         {TAB_NAMES.map((group_name, i) => (
                             <Tab
                                 key={group_name}
@@ -151,14 +159,14 @@ function Leadership() {
                                     leadership[group_name].slug,
                                     i
                                 )}
-                                role={"tab"}
+                                role="tab"
                             >
                                 {group_name}
                             </Tab>
                         ))}
                     </TabGroup>
                 </TabNav>
-                <TabInfo>
+                <TabInfo role="tabpanel">
                     <TabName>{TAB_NAMES[currentTabIndex]}</TabName>
                     <TabDescription>
                         {getCurrentTab().description}

--- a/src/components/Leadership/Leadership.jsx
+++ b/src/components/Leadership/Leadership.jsx
@@ -90,7 +90,10 @@ function Leadership() {
     const [currentTabIndex, setCurrentTabIndex] = useState(0);
     const location = useLocation();
     // when the selected tab changes (keyboard, click, or routing with non-empty hash), focus it
-    const selectedTabRef = useCallback(node => location.hash && node?.focus(), []);
+    const selectedTabRef = useCallback(
+        (node) => location.hash && node?.focus(),
+        []
+    );
 
     const getCurrentTab = () => getTab(currentTabIndex);
 
@@ -135,13 +138,18 @@ function Leadership() {
                         {TAB_NAMES.map((group_name, i) => (
                             <Tab
                                 key={group_name}
+                                id={`tab-${group_name}`}
                                 to={{ hash: `#${leadership[group_name].slug}` }}
                                 onKeyDown={handleKeyDown}
                                 isActive={() => currentTabIndex === i}
                                 role="tab"
-                                tabIndex={currentTabIndex === i ? "0" : "-1"}
+                                tabIndex={currentTabIndex === i ? 0 : -1}
                                 aria-selected={currentTabIndex === i}
-                                ref={currentTabIndex === i ? selectedTabRef : null}
+                                ref={
+                                    currentTabIndex === i
+                                        ? selectedTabRef
+                                        : null
+                                }
                             >
                                 {group_name}
                             </Tab>
@@ -154,10 +162,15 @@ function Leadership() {
                         {getCurrentTab().description}
                     </TabDescription>
                 </TabInfo>
-                <CardContainer
-                    role="tabpanel"
-                    people={getCurrentTab().people}
-                />
+                {TAB_NAMES.map((group_name, i) => (
+                    <CardContainer
+                        key={group_name}
+                        aria-labelledby={`tab-${group_name}`}
+                        role="tabpanel"
+                        people={leadership[group_name].people}
+                        hidden={currentTabIndex !== i}
+                    />
+                ))}
             </LeadershipWrapper>
         </>
     );

--- a/src/components/Leadership/Leadership.jsx
+++ b/src/components/Leadership/Leadership.jsx
@@ -4,13 +4,9 @@ import "utility/fonts.css";
 import Navbar from "components/Navbar.jsx";
 import { NavLink, useLocation } from "react-router-dom";
 import CardContainer from "./CardContainer.jsx";
-import CoreTeam from "assets/CoreTeam.JPG";
-import ErichHands from "assets/ErichHands.JPG";
-import Escapade from "assets/Escapade.JPG";
-import { slugify } from "utility/utils";
 import devices from "utility/MediaQueries.js";
 
-import leadership_json from "leadership.json";
+import leadership from "leadership.json";
 
 // TODO: do we really need this?
 const LeadershipWrapper = styled.main`
@@ -81,32 +77,6 @@ const TabDescription = styled.p`
     color: white;
 `;
 
-const leadGroupPicsGenerator = function* () {
-    yield CoreTeam;
-    yield ErichHands;
-    yield Escapade;
-};
-
-const leadGroupPics = leadGroupPicsGenerator();
-
-// TODO: change leadership.json format
-const leadership = JSON.parse(JSON.stringify(leadership_json));
-Object.keys(leadership).map(
-    (groupName) =>
-        (leadership[groupName] = {
-            description: `${groupName} `.repeat(20),
-            slug: slugify(groupName),
-            people: leadership[groupName],
-            image: leadGroupPics.next().value,
-        })
-);
-/*
- * "Executive Team": {
- *    slug: "executive-team",
- *    people: [...],
- * }
- *
- */
 
 const TAB_NAMES = Object.keys(leadership);
 const getTab = (tabIndex) => leadership[TAB_NAMES[tabIndex]];
@@ -140,7 +110,7 @@ function Leadership() {
                     {TAB_NAMES.map((group_name, i) => (
                         <LeadershipGroupImage
                             key={group_name}
-                            src={leadership[group_name].image}
+                            src={`${process.env.PUBLIC_URL}/${leadership[group_name].imageUrl}`}
                             isActive={isActive(leadership[group_name].slug, i)(
                                 null,
                                 location

--- a/src/components/Leadership/Leadership.jsx
+++ b/src/components/Leadership/Leadership.jsx
@@ -50,6 +50,7 @@ const Tab = styled(NavLink)`
     flex-grow: 1;
     text-align: center;
     color: white;
+    font-size: 1.3em;
     transition: background-color 0.3s;
     &.active {
         background-color: #8dcadf;

--- a/src/components/Leadership/Leadership.jsx
+++ b/src/components/Leadership/Leadership.jsx
@@ -23,9 +23,7 @@ const LeadershipGroupImages = styled.div`
     `}
 `;
 
-const LeadershipGroupImage = styled.img.attrs((props) => ({
-    isActive: props.isActive,
-}))`
+const LeadershipGroupImage = styled.img`
     width: 33.3%;
     height: 400px;
     background-color: lightgray;
@@ -81,32 +79,27 @@ const tabNavigationActions = {
     ArrowLeft: (idx) => idx - 1,
     ArrowRight: (idx) => idx + 1,
     Home: () => 0,
-    End: () => Infinity,
+    End: () => -1,
 };
-
-function clamp(val, min, max) {
-    return Math.min(max, Math.max(val, min));
-}
 
 const TAB_NAMES = Object.keys(leadership);
 const getTab = (tabIndex) => leadership[TAB_NAMES[tabIndex]];
 
 function Leadership() {
-    const [currentTabIndex, _setCurrentTabIndex] = useState(0);
+    const [currentTabIndex, setCurrentTabIndex] = useState(0);
     const location = useLocation();
 
     const getCurrentTab = () => getTab(currentTabIndex);
 
     // TODO: shift focus to the correct tab
     //       will probably need refs
+    // Update the hash first; the next render will update the currentTabIndex
     const handleKeyDown = (event) => {
         if (event.key in tabNavigationActions) {
             window.location.hash = getTab(
-                clamp(
-                    tabNavigationActions[event.key](currentTabIndex),
-                    0,
-                    TAB_NAMES.length - 1
-                )
+                (tabNavigationActions[event.key](currentTabIndex) +
+                    TAB_NAMES.length) %
+                    TAB_NAMES.length
             ).slug;
             event.preventDefault();
             event.stopPropagation();
@@ -119,7 +112,7 @@ function Leadership() {
             (groupName) =>
                 leadership[groupName].slug === location.hash.substring(1)
         );
-        _setCurrentTabIndex(hashIndex !== -1 ? hashIndex : 0);
+        setCurrentTabIndex(hashIndex !== -1 ? hashIndex : 0);
     }, [location]);
 
     return (
@@ -142,19 +135,18 @@ function Leadership() {
                             <Tab
                                 key={group_name}
                                 to={{ hash: `#${leadership[group_name].slug}` }}
-                                // onClick={() => _setCurrentTabIndex(i)}
                                 onKeyDown={handleKeyDown}
                                 isActive={() => currentTabIndex === i}
                                 role="tab"
                                 tabIndex={currentTabIndex === i ? "0" : "-1"}
-                                ariaSelected={currentTabIndex === i}
+                                aria-selected={currentTabIndex === i}
                             >
                                 {group_name}
                             </Tab>
                         ))}
                     </TabGroup>
                 </TabNav>
-                <TabInfo role="tabpanel" tabIndex="0">
+                <TabInfo role="tabpanel">
                     <TabName>{TAB_NAMES[currentTabIndex]}</TabName>
                     <TabDescription>
                         {getCurrentTab().description}

--- a/src/components/Leadership/Leadership.jsx
+++ b/src/components/Leadership/Leadership.jsx
@@ -1,7 +1,7 @@
 import React from "react";
-import "../../utility/fonts.css";
-import SubpageOuter from "../SubpageOuter/SubpageOuter.jsx";
-import Navbar from "../Navbar.jsx";
+import "utility/fonts.css";
+import SubpageOuter from "components/SubpageOuter/SubpageOuter.jsx";
+import Navbar from "components/Navbar.jsx";
 import CardContainer from "./CardContainer.jsx";
 
 const Leadership = () => (

--- a/src/components/Leadership/MemberCard.jsx
+++ b/src/components/Leadership/MemberCard.jsx
@@ -1,5 +1,5 @@
 import React from "react";
-import "../../utility/fonts.css";
+import "utility/fonts.css";
 import styled, { css } from "styled-components";
 import PropTypes from "prop-types";
 

--- a/src/components/Leadership/MemberCard.jsx
+++ b/src/components/Leadership/MemberCard.jsx
@@ -27,6 +27,7 @@ const Card = styled.article`
     text-align: center;
     padding: 20px 30px 30px;
     box-sizing: border-box;
+    border-radius: 10px;
     align-content: center;
     margin-bottom: 5%;
     margin-left: 5px;

--- a/src/components/Leadership/MemberCard.jsx
+++ b/src/components/Leadership/MemberCard.jsx
@@ -44,7 +44,6 @@ const Card = styled.div`
     margin-left: 5px;
     margin-right: 5px;
     font-size: 13px;
-    font: comic-sans;
     ${specificResponsiveness`
     box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.2);
     width: 290px;
@@ -77,112 +76,129 @@ const Title = styled.p`
   `}
 `;
 
-const DetailsCategoryContainer = styled.div`
-    color: black;
-    text-align: left;
-`;
+const DetailsCategoryContainer = styled.dl`
+  display: flex;
+  flex-flow: column wrap;
+  align-items: flex-start;
+  
+ `;
 
-const DetailsCategory = styled.div`
-    color: rgb(241, 93, 36);
-    display: inline;
-`;
+const DetailsCategory = styled.dt`
+   color: rgb(241, 93, 36);
+  padding: 0;
+  flex-basis: auto;
+  flex-grow: 1;
+  margin-bottom:0 ;
+ `;
 
-const DetailsCategoryDescription = styled.div`
-    display: inline;
-`;
+const DetailsCategoryDescription = styled.dd`
+   color: black;
+  flex-basis: 50%;
+  flex-grow: 2;
+  text-align: left;
+  margin-bottom: 0.4em;
+ `;
 
 const IconLink = styled.a`
-    text-decoration: none !important;
-    font-size: 19px !important;
-    color: rgb(241, 93, 36) !important;
-    padding: 10px !important;
+    color: rgb(241, 93, 36);
+    text-decoration: none;
+    font-size: 2em;
+    transition: color 0.3s;
+    &:hover {
+      color: #404040;
+    }
 `;
 
-const Links = styled.div`
+const Links = styled.ul`
     display: inline-block;
     color: rgb(241, 93, 36);
+    // remove default list styling
+    padding-left: 0;
     ${specificResponsiveness`
-    width: 100%;
-  `}
+      width: 100%;
+    `}
 `;
 
-class MemberCard extends React.Component {
-    nonemptyUrls() {
-        const returnValue = [];
+const LinkItem = styled.li`
+    padding: 10px;
+    display: inline;
+`;
 
-        if (this.props.instagramUrl !== "") {
-            returnValue.push(
-                <IconLink key="insta" href={this.props.instagramUrl}>
-                  <FontAwesomeIcon icon={['fab', 'instagram']} />
-                </IconLink>
+const MemberCard = (props) => {
+    const personalUrls = () => {
+        const urls = [];
+        if (props.instagramUrl) {
+            urls.push(
+                <LinkItem key="insta">
+                    <IconLink href={props.instagramUrl}>
+                        <FontAwesomeIcon icon={["fab", "instagram"]} />
+                    </IconLink>
+                </LinkItem>
             );
         }
-        if (this.props.githubUrl !== "") {
-            returnValue.push(
-                <IconLink key="git" href={this.props.githubUrl}>
-                  <FontAwesomeIcon icon={['fab', 'github']} />
-                </IconLink>
+        if (props.githubUrl) {
+            urls.push(
+                <LinkItem key="git">
+                    <IconLink href={props.githubUrl}>
+                        <FontAwesomeIcon icon={["fab", "github"]} />
+                    </IconLink>
+                </LinkItem>
             );
         }
-        if (this.props.linkedinUrl !== "") {
-            returnValue.push(
-                <IconLink key="linked" href={this.props.linkedinUrl}>
-                  <FontAwesomeIcon icon={['fab', 'linkedin']} />
-                </IconLink>
+        if (props.linkedinUrl) {
+            urls.push(
+                <LinkItem key="linked">
+                    <IconLink href={props.linkedinUrl}>
+                        <FontAwesomeIcon icon={["fab", "linkedin"]} />
+                    </IconLink>
+                </LinkItem>
             );
         }
-        if (this.props.facebookUrl !== "") {
-            returnValue.push(
-                <IconLink key="fb" href={this.props.facebookUrl}>
-                  <FontAwesomeIcon icon={['fab', 'facebook']} />
-                </IconLink>
+        if (props.facebookUrl) {
+            urls.push(
+                <LinkItem key="fb">
+                    <IconLink href={props.facebookUrl}>
+                        <FontAwesomeIcon icon={["fab", "facebook"]} />
+                    </IconLink>
+                </LinkItem>
             );
         }
-        if (this.props.personalUrl !== "") {
-            returnValue.push(
-                <IconLink key="personal" href={this.props.personalUrl}>
-                  <FontAwesomeIcon icon={['fab', 'user']} />
-                </IconLink>
+        if (props.personalUrl) {
+            urls.push(
+                <LinkItem key="personal">
+                    <IconLink href={props.personalUrl}>
+                        <FontAwesomeIcon icon={["far", "user"]} />
+                    </IconLink>
+                </LinkItem>
             );
         }
 
-        return returnValue;
-    }
+        return urls;
+    };
 
-    render() {
-        return (
-            <Card>
-                <Leadership
-                    src={this.props.imageUrl}
-                    alt="leadership"
-                    loading="lazy"
-                />
-                <MemberName>{this.props.name}</MemberName>
-                <Title>{this.props.title}</Title>
-                <DetailsCategoryContainer>
-                    <DetailsCategory>Grad Year: </DetailsCategory>
-                    <DetailsCategoryDescription>
-                        {this.props.gradYear}
-                    </DetailsCategoryDescription>
-                </DetailsCategoryContainer>
-                <DetailsCategoryContainer>
-                    <DetailsCategory>Interests: </DetailsCategory>
-                    <DetailsCategoryDescription>
-                        {this.props.interests}
-                    </DetailsCategoryDescription>
-                </DetailsCategoryContainer>
-                <DetailsCategoryContainer>
-                    <DetailsCategory>Fun fact: </DetailsCategory>
-                    <DetailsCategoryDescription>
-                        {this.props.funFact}
-                    </DetailsCategoryDescription>
-                </DetailsCategoryContainer>
-                <p>{this.props.bio}</p>
-                <Links>{this.nonemptyUrls()}</Links>
-            </Card>
-        );
-    }
-}
+    return (
+        <Card>
+            <Leadership src={props.imageUrl} alt="leadership" loading="lazy" />
+            <MemberName>{props.name}</MemberName>
+            <Title>{props.title}</Title>
+            <DetailsCategoryContainer>
+                <DetailsCategory>Grad Year: </DetailsCategory>
+                <DetailsCategoryDescription>
+                    {props.gradYear}
+                </DetailsCategoryDescription>
+                <DetailsCategory>Interests: </DetailsCategory>
+                <DetailsCategoryDescription>
+                    {props.interests}
+                </DetailsCategoryDescription>
+                <DetailsCategory>Fun fact: </DetailsCategory>
+                <DetailsCategoryDescription>
+                    {props.funFact}
+                </DetailsCategoryDescription>
+            </DetailsCategoryContainer>
+            <Links>{personalUrls()}</Links>
+        </Card>
+    );
+};
 
 MemberCard.defaultProps = {
     instagramUrl: "",
@@ -193,6 +209,14 @@ MemberCard.defaultProps = {
 };
 
 MemberCard.propTypes = {
+    name: PropTypes.string,
+    title: PropTypes.string,
+    imageUrl: PropTypes.string,
+    gradYear: PropTypes.string,
+    interests: PropTypes.string,
+    funFact: PropTypes.string,
+    bio: PropTypes.string,
+
     instagramUrl: PropTypes.string,
     githubUrl: PropTypes.string,
     linkedinUrl: PropTypes.string,

--- a/src/components/Leadership/MemberCard.jsx
+++ b/src/components/Leadership/MemberCard.jsx
@@ -17,8 +17,7 @@ const Leadership = styled.img`
     object-fit: cover;
     border-radius: 200px;
     box-sizing: border-box;
-    background-color: #d15c19;
-    border: 7px solid #d15c19;
+    border: 7px solid white;
     width: 100%;
     ${specificResponsiveness`
     height: 190px;
@@ -30,8 +29,9 @@ const Leadership = styled.img`
   `}
 `;
 
-const Card = styled.div`
-    box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.2);
+const Card = styled.article`
+  background-color: #ED8246;
+  //box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.2);
     width: 300px;
     height: 525px;
     text-align: center;
@@ -45,7 +45,7 @@ const Card = styled.div`
     margin-right: 5px;
     font-size: 13px;
     ${specificResponsiveness`
-    box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.2);
+    // box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.2);
     width: 290px;
     height: auto;
     text-align: center;
@@ -62,13 +62,15 @@ const MemberName = styled.h2`
     font-size: 19px;
     margin-top: 10px;
     font-weight: 500;
+  color: white;
     ${specificResponsiveness`
     font-size: 20px;
   `}
 `;
 
 const Title = styled.p`
-    color: rgb(241, 93, 36);
+    //color: rgb(241, 93, 36);
+  color: white;
     font-size: 14px;
     font-weight: 600;
     ${specificResponsiveness`
@@ -84,7 +86,8 @@ const DetailsCategoryContainer = styled.dl`
  `;
 
 const DetailsCategory = styled.dt`
-   color: rgb(241, 93, 36);
+  color: white;
+   //color: rgb(241, 93, 36);
   padding: 0;
   flex-basis: auto;
   flex-grow: 1;
@@ -92,7 +95,7 @@ const DetailsCategory = styled.dt`
  `;
 
 const DetailsCategoryDescription = styled.dd`
-   color: black;
+   color: white;
   flex-basis: 50%;
   flex-grow: 2;
   text-align: left;
@@ -100,7 +103,8 @@ const DetailsCategoryDescription = styled.dd`
  `;
 
 const IconLink = styled.a`
-    color: rgb(241, 93, 36);
+    color: white;
+    //color: rgb(241, 93, 36);
     text-decoration: none;
     font-size: 2em;
     transition: color 0.3s;
@@ -111,7 +115,8 @@ const IconLink = styled.a`
 
 const Links = styled.ul`
     display: inline-block;
-    color: rgb(241, 93, 36);
+    //color: rgb(241, 93, 36);
+    color: white;
     // remove default list styling
     padding-left: 0;
     ${specificResponsiveness`

--- a/src/components/Leadership/MemberCard.jsx
+++ b/src/components/Leadership/MemberCard.jsx
@@ -1,106 +1,92 @@
 import React from "react";
 import "utility/fonts.css";
-import styled, { css } from "styled-components";
+import styled from "styled-components";
 import PropTypes from "prop-types";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-
-const specificResponsiveness = (...args) =>
-    css`
-        @media all and (min-width: 214px) and (max-width: 600px) {
-            ${css(...args)};
-        }
-    `;
+import devices from "utility/MediaQueries.js";
 
 const Leadership = styled.img`
     height: 200px;
+    width: 200px;
     display: block;
     object-fit: cover;
-    border-radius: 200px;
+    border-radius: 100%;
     box-sizing: border-box;
     border: 7px solid white;
-    width: 100%;
-    ${specificResponsiveness`
-    height: 190px;
-    display: block;
-    border-radius: 200px;
-    box-sizing: border-box;
-    background-color: #d15c19;
-    border: 7px solid #d15c19;
+    margin: 0 auto;
+    ${devices.small`
+      height: 150px;
+      width: 150px;
   `}
 `;
 
 const Card = styled.article`
-  background-color: #ED8246;
-  //box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.2);
+    background-color: #ed8246;
     width: 300px;
-    height: 525px;
+    height: 550px;
     text-align: center;
-    flex: 0 1 24%;
-    padding: 50px;
-    padding-top: 20px;
+    padding: 20px 30px 30px;
     box-sizing: border-box;
     align-content: center;
     margin-bottom: 5%;
     margin-left: 5px;
     margin-right: 5px;
-    font-size: 13px;
-    ${specificResponsiveness`
-    // box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.2);
-    width: 290px;
-    height: auto;
-    text-align: center;
-    flex: 0 1 24%;
-    box-sizing: border-box;;
-    align-content: center;
-    margin-bottom: 5%;
-    margin-right: 0px;
-    font-size: 14px;
+    font-size: 1em;
+    ${devices.small`
+      font-size: 1em;
+      height: 475px;
   `}
 `;
 
 const MemberName = styled.h2`
-    font-size: 19px;
+    font-size: 1.2em;
     margin-top: 10px;
     font-weight: 500;
-  color: white;
-    ${specificResponsiveness`
-    font-size: 20px;
+    color: white;
+    ${devices.small`
+      font-size: 20px;
+    font-size: 1.1em;
   `}
 `;
 
 const Title = styled.p`
     //color: rgb(241, 93, 36);
-  color: white;
-    font-size: 14px;
+    color: white;
     font-weight: 600;
-    ${specificResponsiveness`
-    font-size: 15px;
-  `}
+    font-size: 1.1em;
+    ${devices.small`
+      font-size: 1em;
+    `}
 `;
 
-const DetailsCategoryContainer = styled.dl`
-  display: flex;
-  flex-flow: column wrap;
-  align-items: flex-start;
-  
- `;
+const Details = styled.dl`
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+`;
 
-const DetailsCategory = styled.dt`
-  color: white;
-   //color: rgb(241, 93, 36);
-  padding: 0;
-  flex-basis: auto;
-  flex-grow: 1;
-  margin-bottom:0 ;
- `;
+const DetailGroup = styled.div`
+    text-align: left;
+    width: 100%;
+    margin-bottom: 0.2em;
+    &:last-of-type {
+        margin-bottom: 0;
+    }
+`;
 
-const DetailsCategoryDescription = styled.dd`
-   color: white;
-  flex-basis: 50%;
-  flex-grow: 2;
-  text-align: left;
-  margin-bottom: 0.4em;
- `;
+const Detail = styled.dt`
+    display: inline;
+    color: white;
+    //color: rgb(241, 93, 36);
+    padding: 0;
+    margin-bottom: 0;
+`;
+
+const DetailDescription = styled.dd`
+    display: inline;
+    color: white;
+    text-align: left;
+`;
 
 const IconLink = styled.a`
     color: white;
@@ -109,7 +95,7 @@ const IconLink = styled.a`
     font-size: 2em;
     transition: color 0.3s;
     &:hover {
-      color: #404040;
+        color: #404040;
     }
 `;
 
@@ -119,7 +105,7 @@ const Links = styled.ul`
     color: white;
     // remove default list styling
     padding-left: 0;
-    ${specificResponsiveness`
+    ${devices.small`
       width: 100%;
     `}
 `;
@@ -186,20 +172,20 @@ const MemberCard = (props) => {
             <Leadership src={props.imageUrl} alt="leadership" loading="lazy" />
             <MemberName>{props.name}</MemberName>
             <Title>{props.title}</Title>
-            <DetailsCategoryContainer>
-                <DetailsCategory>Grad Year: </DetailsCategory>
-                <DetailsCategoryDescription>
-                    {props.gradYear}
-                </DetailsCategoryDescription>
-                <DetailsCategory>Interests: </DetailsCategory>
-                <DetailsCategoryDescription>
-                    {props.interests}
-                </DetailsCategoryDescription>
-                <DetailsCategory>Fun fact: </DetailsCategory>
-                <DetailsCategoryDescription>
-                    {props.funFact}
-                </DetailsCategoryDescription>
-            </DetailsCategoryContainer>
+            <Details>
+                <DetailGroup>
+                    <Detail>Grad Year: </Detail>
+                    <DetailDescription>{props.gradYear}</DetailDescription>
+                </DetailGroup>
+                <DetailGroup>
+                    <Detail>Interests: </Detail>
+                    <DetailDescription>{props.interests}</DetailDescription>
+                </DetailGroup>
+                <DetailGroup>
+                    <Detail>Fun fact: </Detail>
+                    <DetailDescription>{props.funFact}</DetailDescription>
+                </DetailGroup>
+            </Details>
             <Links>{personalUrls()}</Links>
         </Card>
     );

--- a/src/components/Leadership/MemberCard.jsx
+++ b/src/components/Leadership/MemberCard.jsx
@@ -2,6 +2,7 @@ import React from "react";
 import "utility/fonts.css";
 import styled, { css } from "styled-components";
 import PropTypes from "prop-types";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 
 const specificResponsiveness = (...args) =>
     css`
@@ -112,35 +113,35 @@ class MemberCard extends React.Component {
         if (this.props.instagramUrl !== "") {
             returnValue.push(
                 <IconLink key="insta" href={this.props.instagramUrl}>
-                    <i className="fa fa-instagram"></i>
+                  <FontAwesomeIcon icon={['fab', 'instagram']} />
                 </IconLink>
             );
         }
         if (this.props.githubUrl !== "") {
             returnValue.push(
                 <IconLink key="git" href={this.props.githubUrl}>
-                    <i className="fa fa-github"></i>
+                  <FontAwesomeIcon icon={['fab', 'github']} />
                 </IconLink>
             );
         }
         if (this.props.linkedinUrl !== "") {
             returnValue.push(
                 <IconLink key="linked" href={this.props.linkedinUrl}>
-                    <i className="fa fa-linkedin"></i>
+                  <FontAwesomeIcon icon={['fab', 'linkedin']} />
                 </IconLink>
             );
         }
         if (this.props.facebookUrl !== "") {
             returnValue.push(
                 <IconLink key="fb" href={this.props.facebookUrl}>
-                    <i className="fa fa-facebook"></i>
+                  <FontAwesomeIcon icon={['fab', 'facebook']} />
                 </IconLink>
             );
         }
         if (this.props.personalUrl !== "") {
             returnValue.push(
                 <IconLink key="personal" href={this.props.personalUrl}>
-                    <i className="fa fa-user"></i>
+                  <FontAwesomeIcon icon={['fab', 'user']} />
                 </IconLink>
             );
         }

--- a/src/components/Leadership/MemberCard.jsx
+++ b/src/components/Leadership/MemberCard.jsx
@@ -169,7 +169,7 @@ const MemberCard = (props) => {
 
     return (
         <Card>
-            <Leadership src={props.imageUrl} alt="leadership" loading="lazy" />
+            <Leadership src={props.imageUrl} alt="lead photo" loading="lazy" />
             <MemberName>{props.name}</MemberName>
             <Title>{props.title}</Title>
             <Details>

--- a/src/sample-leadership.json
+++ b/src/sample-leadership.json
@@ -1,293 +1,267 @@
 {
-    "Executive Team": [
-        {
-            "name": "Yatharth Chhabra",
-            "uniqname": "ychhabra",
-            "title": "Vice President of External Affairs",
-            "gradYear": "2022",
-            "interests": "Taekwondo, ultimate frisbee, cricket, memes, fingerstyle guitar",
-            "funFact": "Fingertips are dead from playing fingerstyle guitar",
-            "linkedinUrl": "http://www.linkedin.com/in/yatharth-chhabra",
-            "githubUrl": "https://github.com/yatharthchhabra",
-            "imageUrl": "leadership/ychhabra.jpg",
-            "display": "Y"
-        },
-        {
-            "name": "Luc Corriveau",
-            "uniqname": "luccorr",
-            "title": "President",
-            "gradYear": "2022",
-            "interests": "Camping, video games, learning useless skills",
-            "funFact": "Loves to play the bongos",
-            "linkedinUrl": "https://www.linkedin.com/in/luc-corriveau-053a561ab/",
-            "imageUrl": "leadership/luccorr.jpg",
-            "display": "Y"
-        },
-        {
-            "name": "Nikhil Surya Dwibhashyam",
-            "uniqname": "nikhilsd",
-            "title": "Vice President of Internal Affairs",
-            "gradYear": "2022",
-            "interests": "Sanskrit poetry, piano, biking",
-            "funFact": "Lives on a farm",
-            "linkedinUrl": "https://www.linkedin.com/in/nikhilsd/",
-            "personalUrl": "https://nikhilsd.com/",
-            "imageUrl": "leadership/nikhilsd.png",
-            "display": "Y"
-        }
-    ],
-    "Leadership": [
-        {
-            "name": "Rajas Gupta",
-            "uniqname": "rajasg",
-            "title": "Machine Learning Team Lead",
-            "gradYear": "2022",
-            "interests": "Tennis, table tennis, guitar, nature trails, siestas",
-            "funFact": "Can never find where's Waldo",
-            "display": "Y"
-        },
-        {
-            "name": "Keshav Gurushankar",
-            "uniqname": "keshavg",
-            "title": "Web Team Lead",
-            "gradYear": "2023",
-            "interests": "Cooking/Baking, coffee, taekwondo ",
-            "funFact": "Dangerously high caffeine tolerance",
-            "linkedinUrl": "https://www.linkedin.com/in/keshav-gurushankar/",
-            "githubUrl": "https://github.com/kgurushankar",
-            "imageUrl": "leadership/keshavg.jpg",
-            "display": "Y"
-        },
-        {
-            "name": "Andrew Scheffer",
-            "uniqname": "drewskis",
-            "title": "iOS Team Lead",
-            "gradYear": "2024",
-            "interests": "Bonsai taming, ukulele, ham radio",
-            "funFact": "Drinks apple juice out of wine glasses",
-            "linkedinUrl": "https://www.linkedin.com/in/andrew-scheffer-b5bb091b2/",
-            "githubUrl": "https://github.com/schefferac2020",
-            "imageUrl": "leadership/drewskis.jpg",
-            "display": "Y"
-        },
-        {
-            "name": "Abhik Mazumder",
-            "uniqname": "abhikmaz",
-            "title": "Interviewing Team Lead",
-            "gradYear": "2023",
-            "interests": "Soccer, basketball, JavaScript, going out, anime (not a weeb)",
-            "funFact": "Sucks at 5/5 sports he plays",
-            "linkedinUrl": "https://www.linkedin.com/in/abhikmaz/",
-            "githubUrl": "https://github.com/abhiktech",
-            "instagramUrl": "https://www.instagram.com/abhik.mazumder/",
-            "imageUrl": "leadership/abhikmaz.jpg",
-            "display": "Y"
-        },
-        {
-            "name": "Aryan Seth",
-            "uniqname": "aryans",
-            "title": "Embedded Systems Lead",
-            "gradYear": "2023",
-            "interests": "Running, video games, building emulators, cars",
-            "funFact": "Can do a J-turn in a car",
-            "linkedinUrl": "https://www.linkedin.com/in/aryan-seth/",
-            "githubUrl": "https://github.com/aryanseth26",
-            "imageUrl": "leadership/aryans.png",
-            "display": "Y"
-        },
-        {
-            "name": "Yaman Qalieh",
-            "uniqname": "yamanq",
-            "title": "Open-Source Development Lead",
-            "gradYear": "2022",
-            "interests": "Self-hosting, scripting, languages",
-            "funFact": "Uses Arch Linux",
-            "githubUrl": "https://github.com/yamanq/",
-            "imageUrl": "leadership/yamanq.jpg",
-            "display": "Y"
-        },
-        {
-            "name": "Ondrej Kovarik",
-            "uniqname": "ondrejk",
-            "title": "Web Team Lead",
-            "gradYear": "2023",
-            "interests": "Reading, cooking, volleyball, piccolo/flute, parkour",
-            "funFact": "Has 3 citizenships",
-            "imageUrl": "leadership/ondrejk.jpg",
-            "display": "Y"
-        },
-        {
-            "name": "Justin Hutchins",
-            "uniqname": "jushutch",
-            "title": "Security Team Lead",
-            "gradYear": "2022",
-            "interests": "Music, Latin, camping, video games",
-            "funFact": "His middle name is Time",
-            "linkedinUrl": "https://www.linkedin.com/in/jushutch/",
-            "githubUrl": "https://github.com/jushutch",
-            "personalUrl": "https://jushutch.com/",
-            "imageUrl": "leadership/jushutch.jpg",
-            "display": "Y"
-        },
-        {
-            "name": "Anisha Aggarwal",
-            "uniqname": "anishaag",
-            "title": "Security Team Lead",
-            "gradYear": "2024",
-            "interests": "Piano, volleyball, dancing",
-            "funFact": "Has traveled to 6 countries",
-            "linkedinUrl": "www.linkedin.com/in/anisha-aggarwal-06b2281b4",
-            "imageUrl": "leadership/anishaag.jpg",
-            "display": "Y"
-        },
-        {
-            "name": "Frank Wang",
-            "uniqname": "frnkwang",
-            "title": "Android Team Lead",
-            "gradYear": "2024",
-            "interests": "Violin, classical music/EDM, soccer, Smash Bros, taking long walks",
-            "funFact": "Composes in his free time",
-            "linkedinUrl": "https://www.linkedin.com/in/frank-wang-b68a411b6/",
-            "githubUrl": "https://github.com/frnkwang",
-            "instagramUrl": "https://www.instagram.com/frank_wang09/",
-            "imageUrl": "leadership/frnkwang.jpg",
-            "display": "Y"
-        },
-        {
-            "name": "Caleb Gifford",
-            "uniqname": "calebgif",
-            "title": "Android Team Lead",
-            "gradYear": "2023",
-            "interests": "Running, reading, biking, video games",
-            "funFact": "Can play the organ",
-            "githubUrl": "https://github.com/calebgif",
-            "imageUrl": "leadership/calebgif.jpg",
-            "display": "Y"
-        },
-        {
-            "name": "Jaewoo Kim",
-            "uniqname": "kjae",
-            "title": "Machine Learning Game AI Lead",
-            "gradYear": "2023",
-            "interests": "Soccer, volleyball, violin, video games, working out",
-            "funFact": "Came from Korea 7 years ago",
-            "linkedinUrl": "www.linkedin.com/in/jaewoo-kim-95a8581b6",
-            "imageUrl": "leadership/kjae.jpg",
-            "display": "Y"
-        },
-        {
-            "name": "Jonah Ableman",
-            "uniqname": "jableman",
-            "title": "Marketing Team Lead",
-            "gradYear": "2024",
-            "interests": "Music, skateboarding, gaming, guitar, reading",
-            "funFact": "Has broken only two bones, both his pinkies",
-            "linkedinUrl": "https://www.linkedin.com/in/jonah-ableman-2b3842169/",
-            "githubUrl": "https://github.com/Jableman19",
-            "imageUrl": "leadership/jableman.jpg",
-            "display": "Y"
-        },
-        {
-            "name": "Thomas Smith",
-            "uniqname": "thsm",
-            "title": "iOS Team Lead",
-            "gradYear": "2021",
-            "interests": "Backpacking, canoeing, board games",
-            "funFact": "Walks 10+ miles every day",
-            "linkedinUrl": "https://www.linkedin.com/in/thomasebsmith/",
-            "githubUrl": "https://github.com/thomasebsmith",
-            "personalUrl": "https://thomasebsmith.github.io",
-            "imageUrl": "leadership/thsm.png",
-            "display": "Y"
-        },
-        {
-            "name": "Adam Gunn",
-            "uniqname": "asgunn",
-            "title": "Web Team Lead",
-            "gradYear": "2024",
-            "interests": "Water polo, web dev, movies, music, exploring new places",
-            "funFact": "Has 2 cats",
-            "linkedinUrl": "https://www.linkedin.com/in/a-gunn/",
-            "githubUrl": "https://github.com/adamgunn",
-            "imageUrl": "leadership/asgunn.jpg",
-            "display": "Y"
-        },
-        {
-            "name": "Viroshan Narayan",
-            "uniqname": "vnaray",
-            "title": "Interviewing Team Lead",
-            "gradYear": "2023",
-            "interests": "Biking, basketball, movies, ping pong, cars",
-            "funFact": "Prefers driving manual",
-            "linkedinUrl": "https://www.linkedin.com/in/viroshan-narayan",
-            "githubUrl": "https://github.com/ViroNaray",
-            "imageUrl": "leadership/vnaray.png",
-            "display": "Y"
-        }
-    ],
-    "Senior Advisors": [
-        {
-            "name": "Peter Wu",
-            "uniqname": "weirongw",
-            "title": "Senior Advisor",
-            "gradYear": "2023",
-            "interests": "Reading, design, running, cooking, magic",
-            "funFact": "Can run a 4:50 mile",
-            "linkedinUrl": "https://www.linkedin.com/in/weirongw/",
-            "githubUrl": "https://github.com/weirongw23",
-            "facebookUrl": "https://www.facebook.com/profile.php?id=100007462180089",
-            "instagramUrl": "https://www.instagram.com/weirongw/saved/",
-            "imageUrl": "leadership/weirongw.jpg",
-            "display": "Y"
-        },
-        {
-            "name": "Nicholas Konovalenko",
-            "uniqname": "nkono",
-            "title": "Senior Advisor",
-            "gradYear": "2021",
-            "interests": "Competitive chess, trading stocks, kayaking",
-            "funFact": "Completed all of Google FooBar",
-            "linkedinUrl": "https://www.linkedin.com/in/nicholas-konovalenko-2b3258171/",
-            "githubUrl": "https://github.com/Nkonovalenko",
-            "personalUrl": "https://nickono.com",
-            "instagramUrl": "https://www.instagram.com/konic899",
-            "imageUrl": "leadership/nkono.jpg",
-            "display": "Y"
-        },
-        {
-            "name": "David Wang",
-            "uniqname": "daviwang",
-            "title": "Senior Advisor",
-            "gradYear": "2021",
-            "interests": "Reading, the 2019 NBA championship Toronto Raptors, hip-hop/classical music",
-            "funFact": "Is French Canadian",
-            "linkedinUrl": "https://www.linkedin.com/in/davidjrwang/",
-            "imageUrl": "leadership/daviwang.jpg",
-            "display": "Y"
-        },
-        {
-            "name": "Angela Li",
-            "uniqname": "angelai",
-            "title": "Senior Advisor",
-            "gradYear": "2023",
-            "interests": "Painting, animal crossing, step dancing",
-            "funFact": "Is birthday twins with Peter Parker",
-            "linkedinUrl": "https://www.linkedin.com/in/ilangela/",
-            "instagramUrl": "https://www.instagram.com/anglilo/",
-            "imageUrl": "leadership/angelai.jpg",
-            "display": "Y"
-        },
-        {
-            "name": "Ethan Butcher",
-            "uniqname": "ebutch",
-            "title": "Senior Advisor",
-            "gradYear": "2021",
-            "interests": "Photoshop, investing, E-SK8, hockey, guitar",
-            "funFact": "Ran from bulls in Pamplona, Spain",
-            "linkedinUrl": "https://www.linkedin.com/in/ethan-butcher-91361412b/",
-            "instagramUrl": "https://www.instagram.com/ebutch99/",
-            "imageUrl": "leadership/ebutch.png",
-            "display": "Y"
-        }
-    ]
+    "Executive Team": {
+        "slug": "executive-team",
+        "description": "The Executive Team is responsible for overseeing the club as a whole. Their work includes organizing club activities, maintaining corporate partnerships, managing core teams, handling member relations, and defining club vision. The team currently consists of the President, Vice President of External, and Vice President of Internal.",
+        "imageUrl": "leadership/category-executive-team.jpg",
+        "people": [
+            {
+                "name": "Abhik Mazumder",
+                "uniqname": "abhikmaz",
+                "title": "President",
+                "gradYear": "2023",
+                "interests": "Soccer, Basketball, Volleyball, Boba, Singing, Attack on Titan",
+                "funFact": "Was left-handed by birth and is now right-handed",
+                "linkedinUrl": "https://www.linkedin.com/in/abhikmaz/",
+                "githubUrl": "https://github.com/abhiktech",
+                "facebookUrl": "https://www.facebook.com/abhik.mazumder.9/",
+                "instagramUrl": "https://www.instagram.com/abhik.mazumder/",
+                "imageUrl": "leadership/abhikmaz.jpg",
+                "display": "Y"
+            },
+            {
+                "name": "Aryan Seth",
+                "uniqname": "aryans",
+                "title": "VP of External Affairs",
+                "gradYear": "2023",
+                "interests": "Running, video games, building emulators, cars",
+                "funFact": "Can do a J-turn in a car",
+                "linkedinUrl": "https://www.linkedin.com/in/aryan-seth/",
+                "instagramUrl": "https://www.instagram.com/aryan_seth_/",
+                "imageUrl": "leadership/aryans.jpg",
+                "display": "Y"
+            },
+            {
+                "name": "Frank Wang",
+                "uniqname": "frnkwang",
+                "title": "VP of Internal Affairs",
+                "gradYear": "2024",
+                "interests": "Biking, video games, classical music, sleeping",
+                "funFact": "Loves making dumplings from scratch",
+                "linkedinUrl": "https://www.linkedin.com/in/frank-wang-b68a411b6/",
+                "githubUrl": "https://github.com/frnkwang",
+                "instagramUrl": "https://www.instagram.com/frank_wang09/",
+                "imageUrl": "leadership/frnkwang.jpg",
+                "display": "Y"
+            }
+        ]
+    },
+    "Leadership": {
+        "slug": "leadership",
+        "description": "Team Leads are responsible for administering their core teams. Their work includes developing core team content, running meetings during hack nights, managing team members, and representing the club in general. The different teams are - ML, Android, iOS, Web, Security, Quant, Open Source, Embedded Systems, Interviewing, and Design.",
+        "imageUrl": "leadership/category-leadership.jpg",
+        "people": [
+            {
+                "name": "Ondrej Kovarik",
+                "uniqname": "ondrejk",
+                "title": "Web Team Lead",
+                "gradYear": "2023",
+                "interests": "Reading, cooking, volleyball, piccolo/flute, parkour",
+                "funFact": "Has 3 citizenships",
+                "imageUrl": "leadership/ondrejk.jpg",
+                "display": "Y"
+            },
+            {
+                "name": "Adam Gunn",
+                "uniqname": "asgunn",
+                "title": "Web Team Lead",
+                "gradYear": "2024",
+                "interests": "Water polo, web dev, movies, music, exploring new places",
+                "funFact": "Has 2 cats",
+                "linkedinUrl": "https://www.linkedin.com/in/a-gunn/",
+                "githubUrl": "https://github.com/adamgunn",
+                "imageUrl": "leadership/asgunn.jpg",
+                "display": "Y"
+            },
+            {
+                "name": "Keshav Gurushankar",
+                "uniqname": "keshavg",
+                "title": "Web Team Lead",
+                "gradYear": "2023",
+                "interests": "Cooking/Baking, coffee, taekwondo ",
+                "funFact": "Dangerously high caffeine tolerance",
+                "linkedinUrl": "https://www.linkedin.com/in/keshav-gurushankar/",
+                "githubUrl": "https://github.com/kgurushankar",
+                "imageUrl": "leadership/keshavg.jpg",
+                "display": "Y"
+            },
+            {
+                "name": "Viroshan Narayan",
+                "uniqname": "vnaray",
+                "title": "Interviewing Team Lead",
+                "gradYear": "2023",
+                "interests": "Biking, basketball, movies, ping pong, cars",
+                "funFact": "Prefers driving manual",
+                "linkedinUrl": "https://www.linkedin.com/in/viroshan-narayan",
+                "githubUrl": "https://github.com/ViroNaray",
+                "imageUrl": "leadership/vnaray.jpg",
+                "display": "Y"
+            },
+            {
+                "name": "Caleb Gifford",
+                "uniqname": "calebgif",
+                "title": "Android Team Lead",
+                "gradYear": "2023",
+                "interests": "Running, reading, biking, video games",
+                "funFact": "Biked 128 Miles in the Upper Peninsula!",
+                "githubUrl": "https://github.com/calebgif",
+                "imageUrl": "leadership/calebgif.jpg",
+                "display": "Y"
+            },
+            {
+                "name": "Caleb Qiu",
+                "uniqname": "calebqiu",
+                "title": "iOS Team Lead",
+                "gradYear": "2024",
+                "interests": "Tennis, food, hiking, sleeping",
+                "funFact": "Is trilingual-ish",
+                "linkedinUrl": "www.linkedin.com/in/caleb-qiu-464307224",
+                "githubUrl": "https://github.com/Qiucj",
+                "imageUrl": "leadership/calebqiu.jpg",
+                "display": "Y"
+            },
+            {
+                "name": "Andrew Scheffer",
+                "uniqname": "drewskis",
+                "title": "iOS Team Lead",
+                "gradYear": "2024",
+                "interests": "Bonsai taming, ukulele, ham radio",
+                "funFact": "Drinks apple juice out of wine glasses",
+                "linkedinUrl": "https://www.linkedin.com/in/andrew-scheffer-b5bb091b2/",
+                "githubUrl": "https://github.com/schefferac2020",
+                "imageUrl": "leadership/drewskis.jpg",
+                "display": "Y"
+            },
+            {
+                "name": "Morgan VanderLeest",
+                "uniqname": "vandermo",
+                "title": "Security Team Lead",
+                "gradYear": "2025",
+                "interests": "Reading, writing, working out",
+                "funFact": "Has gotten a concussion from running",
+                "linkedinUrl": "https://www.linkedin.com/in/morgan-vanderleest-109bb5204/",
+                "imageUrl": "leadership/vandermo.jpg",
+                "display": "Y"
+            },
+            {
+                "name": "Anisha Aggarwal",
+                "uniqname": "anishaag",
+                "title": "Security Team Lead",
+                "gradYear": "2023",
+                "interests": "Piano, volleyball, dancing, card tricks/games, Marvel",
+                "funFact": "Likes to eat pizza with ranch",
+                "linkedinUrl": "www.linkedin.com/in/anishaaggarwal/",
+                "githubUrl": "https://github.com/anisha2442",
+                "imageUrl": "leadership/anishaag.jpg",
+                "display": "Y"
+            },
+            {
+                "name": "Anthony Li",
+                "uniqname": "lianth",
+                "title": "Open-Source Development Lead",
+                "gradYear": "2024",
+                "interests": "Baking, Games (Tabletop or Video), Philosophy, Reading, Writing",
+                "funFact": "Uses philosophical tangents to deflect questions",
+                "imageUrl": "leadership/lianth.jpg",
+                "display": "Y"
+            },
+            {
+                "name": "Chris Xiao",
+                "uniqname": "chrisx",
+                "title": "Open-Source Development Lead",
+                "gradYear": "2024",
+                "interests": "Food, photography, home automation, web, Linux",
+                "funFact": "He **hates** JavaScript",
+                "linkedinUrl": "https://www.linkedin.com/in/chris-xiao",
+                "githubUrl": "https://github.com/chrisx8",
+                "personalUrl": "https://chrisx.xyz ",
+                "imageUrl": "leadership/chrisx.jpg",
+                "display": "Y"
+            },
+            {
+                "name": "Tate Fisher",
+                "uniqname": "tatefish",
+                "title": "Embedded Systems Co-Lead",
+                "gradYear": "2023",
+                "interests": "Music, biking, tabletop games, electronics, modular synths ",
+                "funFact": "Can recite the first few lines of the Aeneid",
+                "imageUrl": "leadership/tatefish.jpg",
+                "display": "Y"
+            },
+            {
+                "name": "Ian Birley",
+                "uniqname": "ibirley",
+                "title": "Embedded Systems Co-Lead",
+                "gradYear": "2023",
+                "interests": "Biking, Music, Gaming, Language, Movies",
+                "funFact": "Likes cold-brew coffee",
+                "linkedinUrl": "https://www.linkedin.com/in/ian-birley",
+                "imageUrl": "leadership/ibirley.jpg",
+                "display": "Y"
+            },
+            {
+                "name": "Abhimanyu Deshpande",
+                "uniqname": "abhimany",
+                "title": "Quant Lead",
+                "gradYear": "2023",
+                "interests": "Electric guitar, movies, card games, travelling",
+                "funFact": "Likes pineapple on pizza",
+                "linkedinUrl": "https://www.linkedin.com/in/adeshp01/",
+                "imageUrl": "leadership/DEFAULT.png",
+                "display": "Y"
+            },
+            {
+                "name": "Siddharth Nagamangala",
+                "uniqname": "sidnaga",
+                "title": "Android Team Lead",
+                "gradYear": "2023",
+                "interests": "Basketball, Tennis, Travelling, Movies/TV Shows, Piano",
+                "funFact": "Has rode a toy bike down his basement stairs",
+                "display": "Y",
+                "imageUrl": "leadership/DEFAULT.png"
+            },
+            {
+                "name": "Omkar Yadav",
+                "uniqname": "oyadav",
+                "title": "ML Team Lead",
+                "gradYear": "2025",
+                "interests": "Spikeball, Basketball, Watching Football, Chess",
+                "funFact": "Has moved 6 times",
+                "display": "Y",
+                "imageUrl": "leadership/DEFAULT.png"
+            }
+        ]
+    },
+    "Senior Advisors": {
+        "slug": "senior-advisors",
+        "description": "Senior Advisors are former Executive Team and Leadership Team members. Their work includes mentoring current leadership and organizing events with members.",
+        "imageUrl": "leadership/category-senior-advisors.jpg",
+        "people": [
+            {
+                "name": "Peter Wu",
+                "uniqname": "weirongw",
+                "title": "Senior Advisor",
+                "gradYear": "2023",
+                "interests": "Reading, design, running, cooking, magic",
+                "funFact": "Can run a 4:50 mile",
+                "linkedinUrl": "https://www.linkedin.com/in/weirongw/",
+                "githubUrl": "https://github.com/weirongw23",
+                "facebookUrl": "https://www.facebook.com/profile.php?id=100007462180089",
+                "instagramUrl": "https://www.instagram.com/weirongw/saved/",
+                "imageUrl": "leadership/weirongw.jpg",
+                "display": "Y"
+            },
+            {
+                "name": "Yatharth Chhabra",
+                "uniqname": "ychhabra",
+                "title": "Senior Advisor",
+                "gradYear": "2022",
+                "interests": "Taekwondo, ultimate frisbee, cricket, memes, fingerstyle guitar",
+                "funFact": "Fingertips are dead from playing fingerstyle guitar",
+                "linkedinUrl": "http://www.linkedin.com/in/yatharth-chhabra",
+                "githubUrl": "https://github.com/yatharthchhabra",
+                "imageUrl": "leadership/ychhabra.jpg",
+                "display": "Y"
+            }
+        ]
+    }
 }

--- a/src/utility/utils.js
+++ b/src/utility/utils.js
@@ -1,0 +1,12 @@
+/**
+ * Convert a string into a slug-like format
+ * Replace spaces with dashes, casefold letters, and strip out non-alpha-numeric chars
+ * @param {string} str First string
+ * @return {string} Slugified string
+ */
+export function slugify(str) {
+    return str
+        .toLowerCase()
+        .replaceAll(/ /g, "-")
+        .replaceAll(/[^a-z0-9-]/g, "");
+}


### PR DESCRIPTION
Design Refresh for the Leadership Page based on the Design Team's design

- [x] Create **accessible** (per ARIA) tabbed view for different categories (leadership, exec, senior advisors)
- [X] Add additional information to the `leadership.json` file
- [x] Add group photos for each group to the lead data spreadsheet
